### PR TITLE
Make sure to use `str` in `subprocess.check_call`

### DIFF
--- a/jaraco/envs.py
+++ b/jaraco/envs.py
@@ -22,15 +22,15 @@ class VirtualEnv:
     def ensure_env(self):
         if os.path.exists(self.dir):
             return
-        cmd = [sys.executable, '-m', 'virtualenv', self.dir]
+        cmd = [sys.executable, '-m', 'virtualenv', str(self.dir)]
         with contextlib.suppress(AttributeError):
-            cmd += ['--python', self.python]
+            cmd += ['--python', str(self.python)]
         with contextlib.suppress(AttributeError):
             cmd += self.create_opts
         subprocess.check_call(cmd)
 
     def install(self):
-        cmd = [self.exe(), '-m', 'pip', 'install', self.req]
+        cmd = [self.exe(), '-m', 'pip', 'install', str(self.req)]
         env = os.environ.copy()
         env.update(getattr(self, 'install_env', {}))
         subprocess.check_call(cmd, env=env)
@@ -51,9 +51,9 @@ class _VEnv(VirtualEnv):
 
     def ensure_env(self):
         executable = getattr(self, 'python', sys.executable)
-        cmd = [executable, '-m', 'venv', self.dir]
+        cmd = [executable, '-m', 'venv', str(self.dir)]
         with contextlib.suppress(AttributeError):
-            cmd += ['--python', self.python]
+            cmd += ['--python', str(self.python)]
         with contextlib.suppress(AttributeError):
             cmd += self.create_opts
         subprocess.check_call(cmd)

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -1,0 +1,27 @@
+import subprocess
+from shutil import which
+
+import pytest
+
+from jaraco import envs
+
+
+@pytest.mark.parametrize(
+    "cls,create_opts",
+    [
+        (envs.VirtualEnv, ["--no-setuptools", "--no-pip", "--no-wheel"]),
+        (envs._VEnv, ["--without-pip"]),
+    ],
+)
+def test_ensure_env(tmp_path, cls, create_opts):
+    venv = cls()
+    vars(venv).update(root=tmp_path, name=".venv", create_opts=create_opts)
+    venv.ensure_env()
+
+    possible_bin_dirs = (tmp_path / ".venv/bin", tmp_path / ".venv/Scripts")
+    bin_dir = next(f for f in possible_bin_dirs if f.exists())
+    expected_python = which("python", path=str(bin_dir))
+
+    cmd = [venv.exe(), "-c", "import sys; print(sys.executable)"]
+    out = str(subprocess.check_output(cmd).strip(), "utf-8")
+    assert out == expected_python


### PR DESCRIPTION
For some versions of Python/OS, `subprocess.check_call` might have problems with arguments that are not strings (e.g. pathlib.Path objects) -- [example](https://github.com/abravalheri/setuptools/runs/4628932186?check_suite_focus=true#step:5:671).

The changes introduced here make sure to convert the virtualenv objects attributes to strings before spawning subprocesses.

(It considers attributes like `dir`, `python` and `req` can be given as path objects).

The alternative that is doing nothing and requiring the users to explicitly pass strings is not viable for the `root` and `dir` attributes, since they are expected be path objects that respond to the `/` operation.