### PR TITLE
Add tests for env creation

### DIFF
--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -1,0 +1,27 @@
+import subprocess
+from shutil import which
+
+import pytest
+
+from jaraco import envs
+
+
+@pytest.mark.parametrize(
+    "cls,create_opts",
+    [
+        (envs.VirtualEnv, ["--no-setuptools", "--no-pip", "--no-wheel"]),
+        (envs._VEnv, ["--without-pip"]),
+    ],
+)
+def test_ensure_env(tmp_path, cls, create_opts):
+    venv = cls()
+    vars(venv).update(root=tmp_path, name=".venv", create_opts=create_opts)
+    venv.ensure_env()
+
+    possible_bin_dirs = (tmp_path / ".venv/bin", tmp_path / ".venv/Scripts")
+    bin_dir = next(f for f in possible_bin_dirs if f.exists())
+    expected_python = which("python", path=str(bin_dir))
+
+    cmd = [venv.exe(), "-c", "import sys; print(sys.executable)"]
+    out = str(subprocess.check_output(cmd).strip(), "utf-8")
+    assert out == expected_python

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import subprocess
 from shutil import which
 import pathlib
@@ -29,6 +30,9 @@ path_types = pytest.mark.parametrize(
 )
 
 
+maybe_fspath = os.fspath if sys.version_info < (3, 8) else lambda x: x
+
+
 @env_types
 @path_types
 def test_root_pathlib(tmp_path, cls, create_opts, PathCls):
@@ -38,7 +42,7 @@ def test_root_pathlib(tmp_path, cls, create_opts, PathCls):
 
     possible_bin_dirs = (tmp_path / ".venv/bin", tmp_path / ".venv/Scripts")
     bin_dir = next(f for f in possible_bin_dirs if f.exists())
-    expected_python = which("python", path=bin_dir)
+    expected_python = which("python", path=maybe_fspath(bin_dir))
 
     cmd = [venv.exe(), "-c", "import sys; print(sys.executable)"]
     out = subprocess.check_output(cmd, text=True).strip()

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from shutil import which
 import pathlib
@@ -37,8 +38,8 @@ def test_root_pathlib(tmp_path, cls, create_opts, PathCls):
 
     possible_bin_dirs = (tmp_path / ".venv/bin", tmp_path / ".venv/Scripts")
     bin_dir = next(f for f in possible_bin_dirs if f.exists())
-    expected_python = which("python", path=str(bin_dir))
+    expected_python = which("python", path=bin_dir)
 
     cmd = [venv.exe(), "-c", "import sys; print(sys.executable)"]
     out = subprocess.check_output(cmd, text=True).strip()
-    assert out == expected_python
+    assert os.path.samefile(out, expected_python)

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -17,7 +17,15 @@ env_types = pytest.mark.parametrize(
 )
 
 
-path_types = pytest.mark.parametrize("PathCls", [pathlib.Path, path.Path])
+win37 = 'platform.system() == "Windows" and sys.version_info < (3, 8)'
+
+path_types = pytest.mark.parametrize(
+    "PathCls",
+    [
+        pytest.param(pathlib.Path, marks=pytest.mark.xfail(win37)),
+        path.Path,
+    ],
+)
 
 
 @env_types


### PR DESCRIPTION
Adapted from #3 

- Add tests.
- Run tests against both pathlib.Path and path.Path
