### PR TITLE
tox should call pytest indirectly

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ toxworkdir={env:TOX_WORK_DIR:.tox}
 [testenv]
 deps =
 commands =
-	pytest {posargs}
+	python -m pytest {posargs}
 usedevelop = True
 extras = testing
 


### PR DESCRIPTION
... to get better support for `tox-current-env`.